### PR TITLE
Solve W3C validation errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,7 +196,7 @@ For per field, runtime, specification the attribute can also be passed to the wi
         captcha = fields.ReCaptchaField(
             widget=ReCaptchaV3(
                 attrs={
-                    'required_score':0.85,
+                    'data-required-score':0.85,
                     ...
                 }
             )

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 
 from captcha import client
 from captcha.constants import TEST_PRIVATE_KEY, TEST_PUBLIC_KEY
-from captcha.widgets import ReCaptchaBase, ReCaptchaV2Checkbox
+from captcha.widgets import ReCaptchaBase, ReCaptchaV2Checkbox, ReCaptchaV2Invisible, ReCaptchaV3
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,9 @@ class ReCaptchaField(forms.CharField):
                 " must be a subclass of captcha.widgets.ReCaptchaBase"
             )
 
-        # reCAPTCHA fields are always required.
-        self.required = True
+        # hidden reCAPTCHA fields are always required.
+        if not isinstance(self.widget, (ReCaptchaV2Invisible, ReCaptchaV3)):
+            self.required = True
 
         # Setup instance variables.
         self.private_key = private_key or getattr(
@@ -85,7 +86,7 @@ class ReCaptchaField(forms.CharField):
                 self.error_messages["captcha_invalid"], code="captcha_invalid"
             )
 
-        required_score = self.widget.attrs.get("required_score")
+        required_score = self.widget.attrs.get("data-required-score")
         if required_score:
             # Our score values need to be floats, as that is the expected
             # response from the Google endpoint. Rather than ensure that on

--- a/captcha/tests/test_fields.py
+++ b/captcha/tests/test_fields.py
@@ -295,7 +295,7 @@ class TestWidgets(TestCase):
     def test_client_success_response_v3(self, mocked_submit):
         class VThreeDomainForm(forms.Form):
             captcha = fields.ReCaptchaField(
-                widget=widgets.ReCaptchaV3(attrs={"required_score": 0.8})
+                widget=widgets.ReCaptchaV3(attrs={"data-required-score": 0.8})
             )
 
         mocked_submit.return_value = RecaptchaResponse(
@@ -309,7 +309,7 @@ class TestWidgets(TestCase):
     def test_client_failure_response_v3(self, mocked_submit):
         class VThreeDomainForm(forms.Form):
             captcha = fields.ReCaptchaField(
-                widget=widgets.ReCaptchaV3(attrs={"required_score": 0.8})
+                widget=widgets.ReCaptchaV3(attrs={"data-required-score": 0.8})
             )
 
         mocked_submit.return_value = RecaptchaResponse(

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -72,8 +72,8 @@ class ReCaptchaV3(ReCaptchaBase):
 
     def __init__(self, api_params=None, *args, **kwargs):
         super().__init__(api_params=api_params, *args, **kwargs)
-        if not self.attrs.get("required_score", None):
-            self.attrs["required_score"] = getattr(
+        if not self.attrs.get("data-required-score", None):
+            self.attrs["data-required-score"] = getattr(
                 settings, "RECAPTCHA_REQUIRED_SCORE", None
             )
 


### PR DESCRIPTION
required_score gives validation error in w3 validation:
<img width="1767" alt="image" src="https://user-images.githubusercontent.com/51402920/218459555-b5362e6e-a811-422f-a4bf-359ab9f4a131.png">

required on hidden inputs gives validation error:
<img width="1783" alt="image" src="https://user-images.githubusercontent.com/51402920/218459684-e3c98d40-30d8-4dea-869c-7b339f71d6a1.png">


We use this package for websites that require WCAG 2.1 (AA) where one of the requirements is that the site passes the https://validator.w3.org validation check.
