### PR TITLE
Mark all V2 captcha widgets as hidden so no label is rendered (+ HTML5 validation fixes 🌈)

### DIFF
--- a/django_recaptcha/tests/test_fields.py
+++ b/django_recaptcha/tests/test_fields.py
@@ -96,13 +96,17 @@ class TestWidgets(TestCase):
 
         form = DefaultCheckForm()
         html = form.as_p()
+        # There should not be a label rendered for the checkbox. The ReCAPTCHA JS generates the label.
+        self.assertNotIn("label", html)
+        # Required is not a valid attribute as we aren't rendering a traditional input
+        # Make sure it is not rendered in the HTML
+        self.assertNotIn("required", html)
         self.assertIn(
             '<script src="https://www.google.com/recaptcha/api.js' '"></script>', html
         )
         self.assertIn('data-size="normal"', html)
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-callback="onSubmit_%s"' % test_hex, html)
-        self.assertIn("required", html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
         self.assertIn("var onSubmit_%s = function(token) {" % test_hex, html)
@@ -130,12 +134,16 @@ class TestWidgets(TestCase):
             '<script src="https://www.google.com/recaptcha/api.js' '?hl=af"></script>',
             html,
         )
+        # There should not be a label rendered for the checkbox. The ReCAPTCHA JS generates the label.
+        self.assertNotIn("label", html)
+        # Required is not a valid attribute as we aren't rendering a traditional input
+        # Make sure it is not rendered in the HTML
+        self.assertNotIn("required", html)
         self.assertIn('data-theme="dark"', html)
         self.assertNotIn('data-callback="onSubmit_%s"' % test_hex, html)
         self.assertIn('data-callback="customCallback"', html)
         self.assertIn('data-size="compact"', html)
         self.assertIn('class="g-recaptcha"', html)
-        self.assertIn("required", html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
         self.assertIn("var onSubmit_%s = function(token) {" % test_hex, html)
@@ -162,13 +170,17 @@ class TestWidgets(TestCase):
 
         form = InvisForm()
         html = form.as_p()
+        # Invisible captchas don't have labels
+        self.assertNotIn("label", html)
+        # Required is not a valid attribute as we aren't rendering a traditional input
+        # Make sure it is not rendered in the HTML
+        self.assertNotIn("required", html)
         self.assertIn(
             '<script src="https://www.google.com/recaptcha/api.js' '"></script>', html
         )
         self.assertIn('data-size="invisible"', html)
         self.assertIn('data-callback="onSubmit_%s"' % test_hex, html)
         self.assertIn('class="g-recaptcha"', html)
-        self.assertIn("required", html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
         self.assertIn("var onSubmit_%s = function(token) {" % test_hex, html)
@@ -203,7 +215,6 @@ class TestWidgets(TestCase):
         self.assertNotIn('data-callback="onSubmit_%s"' % test_hex, html)
         self.assertIn('data-callback="customCallbackInvis"', html)
         self.assertIn('class="g-recaptcha"', html)
-        self.assertIn("required", html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
         self.assertIn("var onSubmit_%s = function(token) {" % test_hex, html)
@@ -239,6 +250,8 @@ class TestWidgets(TestCase):
         )
         # ReCaptcha V3 widget has input_type=hidden, there should be no label element in the html
         self.assertNotIn("label", html)
+        # Required is not a valid attribute as we aren't rendering a traditional input
+        # Make sure it is not rendered in the HTML
         self.assertNotIn("required", html)
 
         self.assertIn('data-size="normal"', html)
@@ -268,6 +281,8 @@ class TestWidgets(TestCase):
         )
         # ReCaptcha V3 widget has input_type=hidden, there should be no label element in the html
         self.assertNotIn("label", html)
+        # Required is not a valid attribute as we aren't rendering a traditional input
+        # Make sure it is not rendered in the HTML
         self.assertNotIn("required", html)
 
         self.assertIn('data-size="normal"', html)

--- a/django_recaptcha/widgets.py
+++ b/django_recaptcha/widgets.py
@@ -57,10 +57,12 @@ class ReCaptchaBase(widgets.Widget):
 
 
 class ReCaptchaV2Checkbox(ReCaptchaBase):
+    input_type = "hidden"
     template_name = "django_recaptcha/widget_v2_checkbox.html"
 
 
 class ReCaptchaV2Invisible(ReCaptchaBase):
+    input_type = "hidden"
     template_name = "django_recaptcha/widget_v2_invisible.html"
 
     def build_attrs(self, base_attrs, extra_attrs=None):


### PR DESCRIPTION
For the `ReCaptchaV2Invisible` widget it does not make sense to show a label. The widget is invisible.

The `ReCaptchaV2Checkbox` widget already renders its own checkbox with an appropriate label. It does not make sense to render another, as that label is not connected to any form input and is an accessibility concern.

As a fortunate side effect of marking the inputs as hidden, the `required` attribute is no longer being included on container `div` element (hidden fields can't be marked `required` in HTML).

This is good because `required` is not a valid HTML attribute in this context and is often flagged by HTML conformance checkers.

See also https://github.com/django-recaptcha/django-recaptcha/issues/212