### PR TITLE
Deprecate `required_score` attribute and make it a parameter instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,16 +219,11 @@ For example:
 RECAPTCHA_REQUIRED_SCORE = 0.85
 ```
 
-For per field, runtime, specification the attribute can also be passed to the widget:
+For per field, runtime, specification the score can also be passed to the widget:
 
 ```python
 captcha = fields.ReCaptchaField(
-    widget=ReCaptchaV3(
-        attrs={
-            'required_score':0.85,
-            ...
-        }
-    )
+    widget=ReCaptchaV3(required_score=0.85)
 )
 ```
 

--- a/django_recaptcha/fields.py
+++ b/django_recaptcha/fields.py
@@ -97,7 +97,7 @@ class ReCaptchaField(forms.CharField):
                 self.error_messages["captcha_invalid"], code="captcha_invalid"
             )
 
-        required_score = self.widget.attrs.get("required_score")
+        required_score = getattr(self.widget, "required_score", None)
         if required_score:
             # Our score values need to be floats, as that is the expected
             # response from the Google endpoint. Rather than ensure that on

--- a/django_recaptcha/tests/test_fields.py
+++ b/django_recaptcha/tests/test_fields.py
@@ -239,11 +239,11 @@ class TestWidgets(TestCase):
         )
         # ReCaptcha V3 widget has input_type=hidden, there should be no label element in the html
         self.assertNotIn("label", html)
+        self.assertNotIn("required", html)
 
         self.assertIn('data-size="normal"', html)
         self.assertIn('data-callback="onSubmit_%s"' % test_hex, html)
         self.assertIn('class="g-recaptcha"', html)
-        self.assertIn("required", html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
         self.assertIn('.g-recaptcha[data-widget-uuid="%s"]' % test_hex, html)
@@ -268,11 +268,11 @@ class TestWidgets(TestCase):
         )
         # ReCaptcha V3 widget has input_type=hidden, there should be no label element in the html
         self.assertNotIn("label", html)
+        self.assertNotIn("required", html)
 
         self.assertIn('data-size="normal"', html)
         self.assertIn('data-callback="onSubmit_%s"' % test_hex, html)
         self.assertIn('class="g-recaptcha"', html)
-        self.assertIn("required", html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
         self.assertIn('.g-recaptcha[data-widget-uuid="%s"]' % test_hex, html)
@@ -308,7 +308,6 @@ class TestWidgets(TestCase):
         self.assertNotIn('data-callback="onSubmit_%s"' % test_hex, html)
         self.assertIn('data-callback="customCallbackInvis"', html)
         self.assertIn('class="g-recaptcha"', html)
-        self.assertIn("required", html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
         self.assertIn('.g-recaptcha[data-widget-uuid="%s"]' % test_hex, html)
@@ -326,11 +325,21 @@ class TestWidgets(TestCase):
             html,
         )
 
+    # TODO: DeprecationWarning: remove backwards compatibility test
+    def test_field_required_score_attribute_html(self):
+        with self.assertWarnsMessage(DeprecationWarning, "required_score"):
+
+            class VThreeDomainForm(forms.Form):
+                captcha = fields.ReCaptchaField(
+                    # required_score is deprecated as an attribute
+                    widget=widgets.ReCaptchaV3(attrs={"required_score": 0.8})
+                )
+
     @patch("django_recaptcha.fields.client.submit")
     def test_client_success_response_v3(self, mocked_submit):
         class VThreeDomainForm(forms.Form):
             captcha = fields.ReCaptchaField(
-                widget=widgets.ReCaptchaV3(attrs={"required_score": 0.8})
+                widget=widgets.ReCaptchaV3(required_score=0.8)
             )
 
         mocked_submit.return_value = RecaptchaResponse(
@@ -344,7 +353,7 @@ class TestWidgets(TestCase):
     def test_client_failure_response_v3(self, mocked_submit):
         class VThreeDomainForm(forms.Form):
             captcha = fields.ReCaptchaField(
-                widget=widgets.ReCaptchaV3(attrs={"required_score": 0.8})
+                widget=widgets.ReCaptchaV3(required_score=0.8)
             )
 
         mocked_submit.return_value = RecaptchaResponse(

--- a/django_recaptcha/widgets.py
+++ b/django_recaptcha/widgets.py
@@ -1,4 +1,5 @@
 import uuid
+import warnings
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -74,12 +75,25 @@ class ReCaptchaV3(ReCaptchaBase):
     input_type = "hidden"
     template_name = "django_recaptcha/widget_v3.html"
 
-    def __init__(self, api_params=None, action=None, *args, **kwargs):
+    def __init__(
+        self, api_params=None, action=None, required_score=None, *args, **kwargs
+    ):
         super().__init__(api_params=api_params, *args, **kwargs)
-        if not self.attrs.get("required_score", None):
-            self.attrs["required_score"] = getattr(
-                settings, "RECAPTCHA_REQUIRED_SCORE", None
+        self.required_score = required_score or getattr(
+            settings, "RECAPTCHA_REQUIRED_SCORE", None
+        )
+
+        # DeprecationWarning: remove this backwards compatibility code in the next major release.
+        if self.attrs.get("required_score", None):
+            warnings.warn(
+                "The required_score attribute is deprecated. Please pass `required_score` as an argument directly to the widget, not as part of `attrs`.",
+                DeprecationWarning,
+                stacklevel=2,
             )
+
+            # Populate required_score from widget attributes for backwards compatibility.
+            self.required_score = self.attrs["required_score"]
+
         self.action = action
 
     def build_attrs(self, base_attrs, extra_attrs=None):


### PR DESCRIPTION
Make it an optional parameter of the ReCaptchaV3 widget constructor.

We still accept it as an attribute for backwards compatibility.

**Motivation**: anything passed to `attrs` ends up rendered in HTML. `required_score` is not a valid HTML attribute and is often flagged by HTML validators. By deprecating and removing required_score as an attribute, we can avoid this issue entirely.

See also https://github.com/django-recaptcha/django-recaptcha/issues/212

