### PR TITLE
Converted inline scripts to external scripts.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include AUTHORS.md
 include CHANGELOG.md
 include LICENSE
 include README.md
+recursive-include django_recaptcha/static *
 recursive-include django_recaptcha/templates *
 recursive-include django_recaptcha/locale *.mo *.po

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
@@ -3,23 +3,20 @@ function main() {
 
     const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
     if (!widgetUUID) {
-      console.warn("reCAPTCHA widget with missing UUID");
-      continue;
+      continue;  // probably not a reCAPTCHA widget added by django-recaptcha
     }
-    console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
     const callbackFunctionName = captchaElement.getAttribute("data-callback");
     if (!callbackFunctionName) {
-      console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
-      continue;
-    }
-    if (window[callbackFunctionName]) {
-      console.warn(`callback function '${callbackFunctionName}' has already been added`);
       continue;
     }
 
+    if (window[callbackFunctionName]) {
+      continue; // callback function may already have been added by another script
+    }
+
     window[callbackFunctionName] = (token) => {
-      console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUUID}'`);
+      // called when user clicks checkbox; use for debugging purposes
     };
 
   }

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
@@ -1,0 +1,36 @@
+(function () {
+
+  function main() {
+    for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
+
+      const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
+      if (!widgetUuid) {
+        console.warn("reCAPTCHA widget with missing UUID");
+        break;
+      }
+      console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
+
+      const callbackFunctionName = captchaElement.getAttribute("data-callback");
+      if (!callbackFunctionName) {
+        console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
+        break;
+      }
+      if (window.hasOwnProperty(callbackFunctionName)) {
+        console.warn(`callback function '${callbackFunctionName}' has already been added`);
+        break;
+      }
+
+      window[callbackFunctionName] = (token) => {
+        console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
+      };
+
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", main);
+  } else {
+    main();
+  }
+
+})();

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
@@ -13,7 +13,7 @@ function main() {
       console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
       break;
     }
-    if (window.hasOwnProperty(callbackFunctionName)) {
+    if (window[callbackFunctionName]) {
       console.warn(`callback function '${callbackFunctionName}' has already been added`);
       break;
     }

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
@@ -4,18 +4,18 @@ function main() {
     const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
     if (!widgetUUID) {
       console.warn("reCAPTCHA widget with missing UUID");
-      break;
+      continue;
     }
     console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
     const callbackFunctionName = captchaElement.getAttribute("data-callback");
     if (!callbackFunctionName) {
       console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
-      break;
+      continue;
     }
     if (window[callbackFunctionName]) {
       console.warn(`callback function '${callbackFunctionName}' has already been added`);
-      break;
+      continue;
     }
 
     window[callbackFunctionName] = (token) => {

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
@@ -6,6 +6,11 @@ function main() {
       continue;  // probably not a reCAPTCHA widget added by django-recaptcha
     }
 
+    const recaptchaType = captchaElement.getAttribute("data-recaptcha-type");
+    if (recaptchaType !== "classic-v2-checkbox") {
+      continue;
+    }
+
     const callbackFunctionName = captchaElement.getAttribute("data-callback");
     if (!callbackFunctionName) {
       continue;

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
@@ -1,36 +1,32 @@
-(function () {
+function main() {
+  for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
 
-  function main() {
-    for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
-
-      const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
-      if (!widgetUuid) {
-        console.warn("reCAPTCHA widget with missing UUID");
-        break;
-      }
-      console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
-
-      const callbackFunctionName = captchaElement.getAttribute("data-callback");
-      if (!callbackFunctionName) {
-        console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
-        break;
-      }
-      if (window.hasOwnProperty(callbackFunctionName)) {
-        console.warn(`callback function '${callbackFunctionName}' has already been added`);
-        break;
-      }
-
-      window[callbackFunctionName] = (token) => {
-        console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
-      };
-
+    const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
+    if (!widgetUuid) {
+      console.warn("reCAPTCHA widget with missing UUID");
+      break;
     }
-  }
+    console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", main);
-  } else {
-    main();
-  }
+    const callbackFunctionName = captchaElement.getAttribute("data-callback");
+    if (!callbackFunctionName) {
+      console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
+      break;
+    }
+    if (window.hasOwnProperty(callbackFunctionName)) {
+      console.warn(`callback function '${callbackFunctionName}' has already been added`);
+      break;
+    }
 
-})();
+    window[callbackFunctionName] = (token) => {
+      console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
+    };
+
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", main);
+} else {
+  main();
+}

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_checkbox.js
@@ -1,16 +1,16 @@
 function main() {
   for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
 
-    const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
-    if (!widgetUuid) {
+    const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
+    if (!widgetUUID) {
       console.warn("reCAPTCHA widget with missing UUID");
       break;
     }
-    console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
+    console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
     const callbackFunctionName = captchaElement.getAttribute("data-callback");
     if (!callbackFunctionName) {
-      console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
+      console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
       break;
     }
     if (window.hasOwnProperty(callbackFunctionName)) {
@@ -19,7 +19,7 @@ function main() {
     }
 
     window[callbackFunctionName] = (token) => {
-      console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
+      console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUUID}'`);
     };
 
   }

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
@@ -13,7 +13,7 @@ function main() {
       console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
       break;
     }
-    if (window.hasOwnProperty(callbackFunctionName)) {
+    if (window[callbackFunctionName]) {
       console.warn(`callback function '${callbackFunctionName}' has already been added`);
       break;
     }

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
@@ -6,6 +6,11 @@ function main() {
       continue;  // probably not a reCAPTCHA widget added by django-recaptcha
     }
 
+    const recaptchaType = captchaElement.getAttribute("data-recaptcha-type");
+    if (recaptchaType !== "classic-v2-invisible") {
+      continue;
+    }
+
     const callbackFunctionName = captchaElement.getAttribute("data-callback");
     if (!callbackFunctionName) {
       continue;

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
@@ -1,0 +1,49 @@
+(function () {
+
+  function main() {
+    for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
+
+      const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
+      if (!widgetUuid) {
+        console.warn("reCAPTCHA widget with missing UUID");
+        break;
+      }
+      console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
+
+      const callbackFunctionName = captchaElement.getAttribute("data-callback");
+      if (!callbackFunctionName) {
+        console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
+        break;
+      }
+      if (window.hasOwnProperty(callbackFunctionName)) {
+        console.warn(`callback function '${callbackFunctionName}' has already been added`);
+        break;
+      }
+
+      const formElement = captchaElement.closest("form");
+      if (!formElement) {
+        console.warn(`reCAPTCHA widget with UUID '${widgetUuid}' is not part of a form`);
+        break;
+      }
+
+      formElement.addEventListener("submit", (event) => {
+        event.preventDefault();
+        grecaptcha.execute();
+      });
+
+      window[callbackFunctionName] = (token) => {
+        console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
+        console.log("submitting form...");
+        formElement.submit();
+      };
+
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", main);
+  } else {
+    main();
+  }
+
+})();

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
@@ -1,16 +1,16 @@
 function main() {
   for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
 
-    const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
-    if (!widgetUuid) {
+    const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
+    if (!widgetUUID) {
       console.warn("reCAPTCHA widget with missing UUID");
       break;
     }
-    console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
+    console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
     const callbackFunctionName = captchaElement.getAttribute("data-callback");
     if (!callbackFunctionName) {
-      console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
+      console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
       break;
     }
     if (window.hasOwnProperty(callbackFunctionName)) {
@@ -20,7 +20,7 @@ function main() {
 
     const formElement = captchaElement.closest("form");
     if (!formElement) {
-      console.warn(`reCAPTCHA widget with UUID '${widgetUuid}' is not part of a form`);
+      console.warn(`reCAPTCHA widget with UUID '${widgetUUID}' is not part of a form`);
       break;
     }
 
@@ -30,7 +30,7 @@ function main() {
     });
 
     window[callbackFunctionName] = (token) => {
-      console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
+      console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUUID}'`);
       console.log("submitting form...");
       formElement.submit();
     };

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
@@ -4,24 +4,24 @@ function main() {
     const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
     if (!widgetUUID) {
       console.warn("reCAPTCHA widget with missing UUID");
-      break;
+      continue;
     }
     console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
     const callbackFunctionName = captchaElement.getAttribute("data-callback");
     if (!callbackFunctionName) {
       console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
-      break;
+      continue;
     }
     if (window[callbackFunctionName]) {
       console.warn(`callback function '${callbackFunctionName}' has already been added`);
-      break;
+      continue;
     }
 
     const formElement = captchaElement.closest("form");
     if (!formElement) {
       console.warn(`reCAPTCHA widget with UUID '${widgetUUID}' is not part of a form`);
-      break;
+      continue;
     }
 
     formElement.addEventListener("submit", (event) => {

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
@@ -1,49 +1,45 @@
-(function () {
+function main() {
+  for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
 
-  function main() {
-    for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
-
-      const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
-      if (!widgetUuid) {
-        console.warn("reCAPTCHA widget with missing UUID");
-        break;
-      }
-      console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
-
-      const callbackFunctionName = captchaElement.getAttribute("data-callback");
-      if (!callbackFunctionName) {
-        console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
-        break;
-      }
-      if (window.hasOwnProperty(callbackFunctionName)) {
-        console.warn(`callback function '${callbackFunctionName}' has already been added`);
-        break;
-      }
-
-      const formElement = captchaElement.closest("form");
-      if (!formElement) {
-        console.warn(`reCAPTCHA widget with UUID '${widgetUuid}' is not part of a form`);
-        break;
-      }
-
-      formElement.addEventListener("submit", (event) => {
-        event.preventDefault();
-        grecaptcha.execute();
-      });
-
-      window[callbackFunctionName] = (token) => {
-        console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
-        console.log("submitting form...");
-        formElement.submit();
-      };
-
+    const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
+    if (!widgetUuid) {
+      console.warn("reCAPTCHA widget with missing UUID");
+      break;
     }
-  }
+    console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", main);
-  } else {
-    main();
-  }
+    const callbackFunctionName = captchaElement.getAttribute("data-callback");
+    if (!callbackFunctionName) {
+      console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
+      break;
+    }
+    if (window.hasOwnProperty(callbackFunctionName)) {
+      console.warn(`callback function '${callbackFunctionName}' has already been added`);
+      break;
+    }
 
-})();
+    const formElement = captchaElement.closest("form");
+    if (!formElement) {
+      console.warn(`reCAPTCHA widget with UUID '${widgetUuid}' is not part of a form`);
+      break;
+    }
+
+    formElement.addEventListener("submit", (event) => {
+      event.preventDefault();
+      grecaptcha.execute();
+    });
+
+    window[callbackFunctionName] = (token) => {
+      console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
+      console.log("submitting form...");
+      formElement.submit();
+    };
+
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", main);
+} else {
+  main();
+}

--- a/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v2_invisible.js
@@ -3,19 +3,16 @@ function main() {
 
     const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
     if (!widgetUUID) {
-      console.warn("reCAPTCHA widget with missing UUID");
-      continue;
+      continue;  // probably not a reCAPTCHA widget added by django-recaptcha
     }
-    console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
     const callbackFunctionName = captchaElement.getAttribute("data-callback");
     if (!callbackFunctionName) {
-      console.warn(`callback function missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
       continue;
     }
+
     if (window[callbackFunctionName]) {
-      console.warn(`callback function '${callbackFunctionName}' has already been added`);
-      continue;
+      continue; // callback function may already have been added by another script
     }
 
     const formElement = captchaElement.closest("form");
@@ -30,8 +27,6 @@ function main() {
     });
 
     window[callbackFunctionName] = (token) => {
-      console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUUID}'`);
-      console.log("submitting form...");
       formElement.submit();
     };
 

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -1,53 +1,49 @@
-(function () {
+function main() {
+  grecaptcha.ready(function () {
+    for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
 
-  function main() {
-    grecaptcha.ready(function () {
-      for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
-
-        const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
-        if (!widgetUuid) {
-          console.warn("reCAPTCHA widget with missing UUID");
-          break;
-        }
-        console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
-
-        const formElement = captchaElement.closest("form");
-        if (!formElement) {
-          console.warn(`reCAPTCHA widget with UUID '${widgetUuid}' is not part of a form`);
-          break;
-        }
-
-        const publicKey = captchaElement.getAttribute("data-sitekey");
-        if (publicKey === null) {
-          console.warn(`public key missing missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
-          break;
-        }
-
-        const actionName = captchaElement.getAttribute("data-action");
-        const config = {};
-        if (actionName !== null) {
-          config.action = actionName;
-        }
-
-        formElement.addEventListener("submit", function (event) {
-          event.preventDefault();
-          grecaptcha.execute(publicKey, config)
-            .then(function (token) {
-              console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
-              captchaElement.value = token;
-              console.log("submitting form...");
-              formElement.submit();
-            });
-        });
-
+      const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
+      if (!widgetUuid) {
+        console.warn("reCAPTCHA widget with missing UUID");
+        break;
       }
-    });
-  }
+      console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", main);
-  } else {
-    main();
-  }
+      const formElement = captchaElement.closest("form");
+      if (!formElement) {
+        console.warn(`reCAPTCHA widget with UUID '${widgetUuid}' is not part of a form`);
+        break;
+      }
 
-})();
+      const publicKey = captchaElement.getAttribute("data-sitekey");
+      if (publicKey === null) {
+        console.warn(`public key missing missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
+        break;
+      }
+
+      const actionName = captchaElement.getAttribute("data-action");
+      const config = {};
+      if (actionName !== null) {
+        config.action = actionName;
+      }
+
+      formElement.addEventListener("submit", function (event) {
+        event.preventDefault();
+        grecaptcha.execute(publicKey, config)
+          .then(function (token) {
+            console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
+            captchaElement.value = token;
+            console.log("submitting form...");
+            formElement.submit();
+          });
+      });
+
+    }
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", main);
+} else {
+  main();
+}

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -7,6 +7,11 @@ function main() {
         continue; // probably not a reCAPTCHA widget added by django-recaptcha
       }
 
+      const recaptchaType = captchaElement.getAttribute("data-recaptcha-type");
+      if (recaptchaType !== "classic-v3") {
+        continue;
+      }
+
       const formElement = captchaElement.closest("form");
       if (!formElement) {
         console.warn(`reCAPTCHA widget with UUID '${widgetUUID}' is not part of a form`);

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -4,10 +4,8 @@ function main() {
 
       const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
       if (!widgetUUID) {
-        console.warn("reCAPTCHA widget with missing UUID");
-        continue;
+        continue; // probably not a reCAPTCHA widget added by django-recaptcha
       }
-      console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
       const formElement = captchaElement.closest("form");
       if (!formElement) {
@@ -31,9 +29,7 @@ function main() {
         event.preventDefault();
         grecaptcha.execute(publicKey, config)
           .then(function (token) {
-            console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUUID}'`);
             captchaElement.value = token;
-            console.log("submitting form...");
             formElement.submit();
           });
       });

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -23,10 +23,11 @@
           break;
         }
 
-        // Google reCAPTCHA expects an object with an optional single key-value
-        // pair to communicate the name of the action.
         const actionName = captchaElement.getAttribute("data-action");
-        const config = actionName !== null ? { action: actionName } : {};
+        const config = {};
+        if (actionName !== null) {
+          config.action = actionName;
+        }
 
         formElement.addEventListener("submit", function (event) {
           event.preventDefault();

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -23,12 +23,14 @@
           break;
         }
 
-        const action = {};
-        Object.assign(action, {action: captchaElement.getAttribute("data-action")});
+        // Google reCAPTCHA expects an object with an optional single key-value
+        // pair to communicate the name of the action.
+        const actionName = captchaElement.getAttribute("data-action");
+        const config = actionName !== null ? { action: actionName } : {};
 
         formElement.addEventListener("submit", function (event) {
           event.preventDefault();
-          grecaptcha.execute(publicKey, action)
+          grecaptcha.execute(publicKey, config)
             .then(function (token) {
               console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
               captchaElement.value = token;

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -1,0 +1,50 @@
+(function () {
+
+  function main() {
+    grecaptcha.ready(function () {
+      for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
+
+        const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
+        if (!widgetUuid) {
+          console.warn("reCAPTCHA widget with missing UUID");
+          break;
+        }
+        console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
+
+        const formElement = captchaElement.closest("form");
+        if (!formElement) {
+          console.warn("reCAPTCHA widget with UUID '" + widgetUuid + "' is not part of a form");
+          break;
+        }
+
+        const publicKey = captchaElement.getAttribute("data-sitekey");
+        if (publicKey === null) {
+          console.warn("public key missing missing from reCAPTCHA widget with UUID '" + widgetUuid + "'");
+          break;
+        }
+
+        const action = {};
+        Object.assign(action, {action: captchaElement.getAttribute("data-action")});
+
+        formElement.addEventListener("submit", function (event) {
+          event.preventDefault();
+          grecaptcha.execute(publicKey, action)
+            .then(function (token) {
+              console.log("reCAPTCHA validated for reCAPTCHA widget with UUID '" + widgetUuid + "'");
+              captchaElement.value = token;
+              console.log("submitting form...");
+              formElement.submit();
+            });
+        });
+
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", main);
+  } else {
+    main();
+  }
+
+})();

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -5,20 +5,20 @@ function main() {
       const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
       if (!widgetUUID) {
         console.warn("reCAPTCHA widget with missing UUID");
-        break;
+        continue;
       }
       console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
       const formElement = captchaElement.closest("form");
       if (!formElement) {
         console.warn(`reCAPTCHA widget with UUID '${widgetUUID}' is not part of a form`);
-        break;
+        continue;
       }
 
       const publicKey = captchaElement.getAttribute("data-sitekey");
       if (publicKey === null) {
         console.warn(`public key missing missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
-        break;
+        continue;
       }
 
       const actionName = captchaElement.getAttribute("data-action");

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -2,22 +2,22 @@ function main() {
   grecaptcha.ready(function () {
     for (const captchaElement of document.querySelectorAll(".g-recaptcha")) {
 
-      const widgetUuid = captchaElement.getAttribute("data-widget-uuid");
-      if (!widgetUuid) {
+      const widgetUUID = captchaElement.getAttribute("data-widget-uuid");
+      if (!widgetUUID) {
         console.warn("reCAPTCHA widget with missing UUID");
         break;
       }
-      console.log(`found reCAPTCHA widget with UUID '${widgetUuid}'`);
+      console.log(`found reCAPTCHA widget with UUID '${widgetUUID}'`);
 
       const formElement = captchaElement.closest("form");
       if (!formElement) {
-        console.warn(`reCAPTCHA widget with UUID '${widgetUuid}' is not part of a form`);
+        console.warn(`reCAPTCHA widget with UUID '${widgetUUID}' is not part of a form`);
         break;
       }
 
       const publicKey = captchaElement.getAttribute("data-sitekey");
       if (publicKey === null) {
-        console.warn(`public key missing missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
+        console.warn(`public key missing missing from reCAPTCHA widget with UUID '${widgetUUID}'`);
         break;
       }
 
@@ -31,7 +31,7 @@ function main() {
         event.preventDefault();
         grecaptcha.execute(publicKey, config)
           .then(function (token) {
-            console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
+            console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUUID}'`);
             captchaElement.value = token;
             console.log("submitting form...");
             formElement.submit();

--- a/django_recaptcha/static/django_recaptcha/js/widget_v3.js
+++ b/django_recaptcha/static/django_recaptcha/js/widget_v3.js
@@ -13,13 +13,13 @@
 
         const formElement = captchaElement.closest("form");
         if (!formElement) {
-          console.warn("reCAPTCHA widget with UUID '" + widgetUuid + "' is not part of a form");
+          console.warn(`reCAPTCHA widget with UUID '${widgetUuid}' is not part of a form`);
           break;
         }
 
         const publicKey = captchaElement.getAttribute("data-sitekey");
         if (publicKey === null) {
-          console.warn("public key missing missing from reCAPTCHA widget with UUID '" + widgetUuid + "'");
+          console.warn(`public key missing missing from reCAPTCHA widget with UUID '${widgetUuid}'`);
           break;
         }
 
@@ -30,7 +30,7 @@
           event.preventDefault();
           grecaptcha.execute(publicKey, action)
             .then(function (token) {
-              console.log("reCAPTCHA validated for reCAPTCHA widget with UUID '" + widgetUuid + "'");
+              console.log(`reCAPTCHA validated for reCAPTCHA widget with UUID '${widgetUuid}'`);
               captchaElement.value = token;
               console.log("submitting form...");
               formElement.submit();

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v2_checkbox.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v2_checkbox.html
@@ -1,4 +1,4 @@
-{# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
+{# Override this template and its logic as needed. #}
 {% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
 <script src="{% static 'django_recaptcha/js/widget_v2_checkbox.js' %}" type="module"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v2_checkbox.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v2_checkbox.html
@@ -1,8 +1,3 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
-<script>
-    // Submit function to be called, after reCAPTCHA was successful.
-    var onSubmit_{{ widget_uuid }} = function(token) {
-        console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'")
-    };
-</script>
+<script src="{{ script_url }}"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v2_checkbox.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v2_checkbox.html
@@ -1,4 +1,4 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
 {% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
-<script src="{% static "django_recaptcha/js/widget_v2_checkbox.js" %}"></script>
+<script src="{% static 'django_recaptcha/js/widget_v2_checkbox.js' %}" type="module"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v2_checkbox.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v2_checkbox.html
@@ -1,3 +1,4 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
+{% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
-<script src="{{ script_url }}"></script>
+<script src="{% static "django_recaptcha/js/widget_v2_checkbox.js" %}"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v2_invisible.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v2_invisible.html
@@ -1,4 +1,4 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
 {% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
-<script src="{% static "django_recaptcha/js/widget_v2_invisible.js" %}"></script>
+<script src="{% static 'django_recaptcha/js/widget_v2_invisible.js' %}" type="module"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v2_invisible.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v2_invisible.html
@@ -1,21 +1,3 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
-<script>
-    // Submit function to be called, after reCAPTCHA was successful.
-    var onSubmit_{{ widget_uuid }} = function(token) {
-        console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Submitting form...")
-        document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]').closest('form').submit();
-    };
-
-    // Helper function to prevent form submission and execute verification.
-    var verifyCaptcha_{{ widget_uuid}} = function(e) {
-        e.preventDefault();
-        grecaptcha.execute();
-    };
-
-    // Bind the helper function to the form submit action.
-    document.addEventListener( 'DOMContentLoaded', function () {
-        var element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
-        element.closest('form').addEventListener('submit', verifyCaptcha_{{ widget_uuid}});
-    });
-</script>
+<script src="{{ script_url }}"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v2_invisible.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v2_invisible.html
@@ -1,3 +1,4 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
+{% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
-<script src="{{ script_url }}"></script>
+<script src="{% static "django_recaptcha/js/widget_v2_invisible.js" %}"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v2_invisible.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v2_invisible.html
@@ -1,4 +1,4 @@
-{# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
+{# Override this template and its logic as needed. #}
 {% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js{% if api_params %}?{{ api_params }}{% endif %}"></script>
 <script src="{% static 'django_recaptcha/js/widget_v2_invisible.js' %}" type="module"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v3.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v3.html
@@ -1,22 +1,3 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js?render={{ public_key }}{% if api_params %}&{{ api_params }}{% endif %}"></script>
-<script>
-    var element
-    grecaptcha.ready(function() {
-        element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
-        element.form.addEventListener('submit', recaptchaFormSubmit);
-    });
-    function recaptchaFormSubmit(event) {
-        event.preventDefault();
-        {% if action %}
-        grecaptcha.execute('{{ public_key }}', {action: '{{ action|escape }}'})
-        {% else %}
-        grecaptcha.execute('{{ public_key }}', {})
-        {% endif %}
-        .then(function(token) {
-            console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Setting input value...")
-            element.value = token;
-            element.form.submit();
-        });
-    }
-</script>
+<script src="{{ script_url }}"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v3.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v3.html
@@ -1,4 +1,4 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
 {% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js?render={{ public_key }}{% if api_params %}&{{ api_params }}{% endif %}"></script>
-<script src="{% static "django_recaptcha/js/widget_v3.js" %}"></script>
+<script src="{% static 'django_recaptcha/js/widget_v3.js' %}" type="module"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v3.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v3.html
@@ -1,3 +1,4 @@
 {# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
+{% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js?render={{ public_key }}{% if api_params %}&{{ api_params }}{% endif %}"></script>
-<script src="{{ script_url }}"></script>
+<script src="{% static "django_recaptcha/js/widget_v3.js" %}"></script>

--- a/django_recaptcha/templates/django_recaptcha/includes/js_v3.html
+++ b/django_recaptcha/templates/django_recaptcha/includes/js_v3.html
@@ -1,4 +1,4 @@
-{# The provided implementation caters for only one reCAPTCHA on a page. Override this template and its logic as needed. #}
+{# Override this template and its logic as needed. #}
 {% load static %}
 <script src="https://{{ recaptcha_domain }}/recaptcha/api.js?render={{ public_key }}{% if api_params %}&{{ api_params }}{% endif %}"></script>
 <script src="{% static 'django_recaptcha/js/widget_v3.js' %}" type="module"></script>

--- a/django_recaptcha/tests/test_fields.py
+++ b/django_recaptcha/tests/test_fields.py
@@ -109,6 +109,7 @@ class TestWidgets(TestCase):
         self.assertIn('data-callback="onSubmit_%s"' % test_hex, html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
+        self.assertIn('data-recaptcha-type="classic-v2-checkbox"', html)
 
     @patch("django_recaptcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)
     def test_v2_checkbox_attribute_changes_html(self, mocked_uuid):
@@ -146,6 +147,7 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha custom-class"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
+        self.assertIn('data-recaptcha-type="classic-v2-checkbox"', html)
 
     @override_settings(RECAPTCHA_DOMAIN="www.recaptcha.net")
     def test_default_v2_checkbox_domain_html(self):
@@ -182,6 +184,7 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
+        self.assertIn('data-recaptcha-type="classic-v2-invisible"', html)
 
     @patch("django_recaptcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)
     def test_v2_invisible_attribute_changes_html(self, mocked_uuid):
@@ -214,6 +217,7 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha custom-class"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
+        self.assertIn('data-recaptcha-type="classic-v2-invisible"', html)
 
     @override_settings(RECAPTCHA_DOMAIN="www.recaptcha.net")
     def test_default_v2_invisible_domain_html(self):
@@ -253,6 +257,7 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
+        self.assertIn('data-recaptcha-type="classic-v3"', html)
 
     @patch("django_recaptcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)
     def test_default_v3_html_with_action(self, mocked_uuid):
@@ -281,6 +286,7 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
+        self.assertIn('data-recaptcha-type="classic-v3"', html)
 
     @patch("django_recaptcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)
     def test_v3_attribute_changes_html(self, mocked_uuid):
@@ -312,6 +318,7 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
+        self.assertIn('data-recaptcha-type="classic-v3"', html)
 
     @override_settings(RECAPTCHA_DOMAIN="www.recaptcha.net")
     def test_default_v3_domain_html(self):

--- a/django_recaptcha/tests/test_fields.py
+++ b/django_recaptcha/tests/test_fields.py
@@ -109,7 +109,6 @@ class TestWidgets(TestCase):
         self.assertIn('data-callback="onSubmit_%s"' % test_hex, html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
-        self.assertIn("var onSubmit_%s = function(token) {" % test_hex, html)
 
     @patch("django_recaptcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)
     def test_v2_checkbox_attribute_changes_html(self, mocked_uuid):
@@ -147,7 +146,6 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha custom-class"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
-        self.assertIn("var onSubmit_%s = function(token) {" % test_hex, html)
 
     @override_settings(RECAPTCHA_DOMAIN="www.recaptcha.net")
     def test_default_v2_checkbox_domain_html(self):
@@ -184,9 +182,6 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
-        self.assertIn("var onSubmit_%s = function(token) {" % test_hex, html)
-        self.assertIn("var verifyCaptcha_%s = function(e) {" % test_hex, html)
-        self.assertIn('.g-recaptcha[data-widget-uuid="%s"]' % test_hex, html)
 
     @patch("django_recaptcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)
     def test_v2_invisible_attribute_changes_html(self, mocked_uuid):
@@ -219,9 +214,6 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha custom-class"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
-        self.assertIn("var onSubmit_%s = function(token) {" % test_hex, html)
-        self.assertIn("var verifyCaptcha_%s = function(e) {" % test_hex, html)
-        self.assertIn('.g-recaptcha[data-widget-uuid="%s"]' % test_hex, html)
 
     @override_settings(RECAPTCHA_DOMAIN="www.recaptcha.net")
     def test_default_v2_invisible_domain_html(self):
@@ -261,9 +253,6 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
-        self.assertIn('.g-recaptcha[data-widget-uuid="%s"]' % test_hex, html)
-        # By default, the action should NOT be in the JS code
-        self.assertNotIn("action", html)
 
     @patch("django_recaptcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)
     def test_default_v3_html_with_action(self, mocked_uuid):
@@ -292,10 +281,6 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
-        self.assertIn('.g-recaptcha[data-widget-uuid="%s"]' % test_hex, html)
-
-        # Expect the action to be in the JS code
-        self.assertIn("action: 'needle'", html)
 
     @patch("django_recaptcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)
     def test_v3_attribute_changes_html(self, mocked_uuid):
@@ -327,7 +312,6 @@ class TestWidgets(TestCase):
         self.assertIn('class="g-recaptcha"', html)
         self.assertIn('data-widget-uuid="%s"' % test_hex, html)
         self.assertIn('data-sitekey="pubkey"', html)
-        self.assertIn('.g-recaptcha[data-widget-uuid="%s"]' % test_hex, html)
 
     @override_settings(RECAPTCHA_DOMAIN="www.recaptcha.net")
     def test_default_v3_domain_html(self):

--- a/django_recaptcha/widgets.py
+++ b/django_recaptcha/widgets.py
@@ -112,3 +112,8 @@ class ReCaptchaV3(ReCaptchaBase):
 
     def value_from_datadict(self, data, files, name):
         return data.get(name)
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context.update({"action": self.action})
+        return context

--- a/django_recaptcha/widgets.py
+++ b/django_recaptcha/widgets.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.forms import widgets
-from django.templatetags.static import static
 
 from django_recaptcha.constants import DEFAULT_RECAPTCHA_DOMAIN
 
@@ -42,7 +41,6 @@ class ReCaptchaBase(widgets.Widget):
                 "recaptcha_domain": getattr(
                     settings, "RECAPTCHA_DOMAIN", DEFAULT_RECAPTCHA_DOMAIN
                 ),
-                "script_url": self.script_name,
             }
         )
         return context
@@ -62,13 +60,11 @@ class ReCaptchaBase(widgets.Widget):
 class ReCaptchaV2Checkbox(ReCaptchaBase):
     input_type = "hidden"
     template_name = "django_recaptcha/widget_v2_checkbox.html"
-    script_name = static("django_recaptcha/js/widget_v2_checkbox.js")
 
 
 class ReCaptchaV2Invisible(ReCaptchaBase):
     input_type = "hidden"
     template_name = "django_recaptcha/widget_v2_invisible.html"
-    script_name = static("django_recaptcha/js/widget_v2_invisible.js")
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
@@ -81,7 +77,6 @@ class ReCaptchaV2Invisible(ReCaptchaBase):
 class ReCaptchaV3(ReCaptchaBase):
     input_type = "hidden"
     template_name = "django_recaptcha/widget_v3.html"
-    script_name = static("django_recaptcha/js/widget_v3.js")
 
     def __init__(
         self, api_params=None, action=None, required_score=None, *args, **kwargs

--- a/django_recaptcha/widgets.py
+++ b/django_recaptcha/widgets.py
@@ -48,6 +48,7 @@ class ReCaptchaBase(widgets.Widget):
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
         attrs["data-widget-uuid"] = self.uuid
+        attrs["data-recaptcha-type"] = self.recaptcha_type
 
         # Support the ability to override some of the Google data attrs.
         attrs["data-callback"] = base_attrs.get(
@@ -59,11 +60,13 @@ class ReCaptchaBase(widgets.Widget):
 
 class ReCaptchaV2Checkbox(ReCaptchaBase):
     input_type = "hidden"
+    recaptcha_type = "classic-v2-checkbox"
     template_name = "django_recaptcha/widget_v2_checkbox.html"
 
 
 class ReCaptchaV2Invisible(ReCaptchaBase):
     input_type = "hidden"
+    recaptcha_type = "classic-v2-invisible"
     template_name = "django_recaptcha/widget_v2_invisible.html"
 
     def build_attrs(self, base_attrs, extra_attrs=None):
@@ -76,6 +79,7 @@ class ReCaptchaV2Invisible(ReCaptchaBase):
 
 class ReCaptchaV3(ReCaptchaBase):
     input_type = "hidden"
+    recaptcha_type = "classic-v3"
     template_name = "django_recaptcha/widget_v3.html"
 
     def __init__(

--- a/django_recaptcha/widgets.py
+++ b/django_recaptcha/widgets.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.forms import widgets
+from django.templatetags.static import static
 
 from django_recaptcha.constants import DEFAULT_RECAPTCHA_DOMAIN
 
@@ -41,6 +42,7 @@ class ReCaptchaBase(widgets.Widget):
                 "recaptcha_domain": getattr(
                     settings, "RECAPTCHA_DOMAIN", DEFAULT_RECAPTCHA_DOMAIN
                 ),
+                "script_url": self.script_name,
             }
         )
         return context
@@ -60,11 +62,13 @@ class ReCaptchaBase(widgets.Widget):
 class ReCaptchaV2Checkbox(ReCaptchaBase):
     input_type = "hidden"
     template_name = "django_recaptcha/widget_v2_checkbox.html"
+    script_name = static("django_recaptcha/js/widget_v2_checkbox.js")
 
 
 class ReCaptchaV2Invisible(ReCaptchaBase):
     input_type = "hidden"
     template_name = "django_recaptcha/widget_v2_invisible.html"
+    script_name = static("django_recaptcha/js/widget_v2_invisible.js")
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
@@ -77,6 +81,7 @@ class ReCaptchaV2Invisible(ReCaptchaBase):
 class ReCaptchaV3(ReCaptchaBase):
     input_type = "hidden"
     template_name = "django_recaptcha/widget_v3.html"
+    script_name = static("django_recaptcha/js/widget_v3.js")
 
     def __init__(
         self, api_params=None, action=None, required_score=None, *args, **kwargs
@@ -101,12 +106,9 @@ class ReCaptchaV3(ReCaptchaBase):
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super().build_attrs(base_attrs, extra_attrs)
+        if self.action:
+            attrs["data-action"] = self.action
         return attrs
 
     def value_from_datadict(self, data, files, name):
         return data.get(name)
-
-    def get_context(self, name, value, attrs):
-        context = super().get_context(name, value, attrs)
-        context.update({"action": self.action})
-        return context


### PR DESCRIPTION
**WORK IN PROGRESS: DO NOT MERGE WITHOUT FURTHER DISCUSSION (HERE OR #101)**

I've tried to convert the inline scripts used by widgets to external scripts without making any changes that would break any existing projects. I was a bit overzealous by removing the method that injects the `action` variable into the V3 widget, because that would break custom widget templates that use that variable, hence the third commit.

This does introduce one change that is potentially breaking: developers need to define a STATIC_ROOT to use static files. In my mind, (almost) every project would set this setting, but it's a breaking change nonetheless. Anyone got any insight in this?

I had to remove the test assertions related to the inline scripts, because those do not exist anymore. I think actual e2e tests should be used in the future to make sure that the implementation actually works.

I tried to replicate the approach/behavior of the original inline scripts in the new external scripts in the same way as the original inline scripts, so that you can compare the two, but there are some major differences:

- I wrapped every script in an IIFE to avoid namespace pollution [1]
- the execution of the scripts is delayed until after the document has been loaded
- I used guards for more feedback; they also prevent breaking things when multiple reCAPTCHA fields are on one page, and/or (at least) one of those reCAPTCHA fields wasn't added by django_recaptcha
- in contrast to injecting variables into the inline scripts of widget templates, the external scripts now check what the name of the callback function should be by looking at the `data-callback` attribute, and then adding the callback function to the global namespace with that name
- similarly, the script of the V3 widget now checks what the action is by looking at the `data-action` attribute

One design choice that I need help with is how the static resource of each widget is defined. Which seems better?

- current solution: injecting the URL into the template 
- normal solution: defining a Media class for the Widget (see [2]) 

I tested these changes against a django project that I whipped up quickly to test each widget and "they worked on my machine". If anyone has any questions, I'll gladly answer them.

[1] [IIFE - MDN Web Docs Glossary](https://developer.mozilla.org/en-US/docs/Glossary/IIFE)
[2] [Form Assets | Django documentation](https://docs.djangoproject.com/en/4.2/topics/forms/media/#assets-as-a-static-definition)