### PR TITLE
Remove RECAPTCHA_SUPPORTED_LANGUAGES.

### DIFF
--- a/django_recaptcha/client.py
+++ b/django_recaptcha/client.py
@@ -6,8 +6,6 @@ from django.conf import settings
 
 from django_recaptcha.constants import DEFAULT_RECAPTCHA_DOMAIN
 
-RECAPTCHA_SUPPORTED_LANUAGES = ("en", "nl", "fr", "de", "pt", "ru", "es", "tr")
-
 
 class RecaptchaResponse:
     def __init__(self, is_valid, error_codes=None, extra_data=None, action=None):


### PR DESCRIPTION
As discussed in #316 by @Stormheg, RECAPTCHA_SUPPORTED_LANGUAGES is not used anywhere within the package, and also isn't part of the package's public API. Since it has no clear purpose, removing it seems like the best option, rather than to keep it and maintain it for no good reason.