### PR TITLE
Add Django 5.1 support and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 Tested with:
 
 - Python: 3.8, 3.9, 3.10, 3.11, 3.12
-- Django: 3.2, 4.1, 4.2, 5.0
+- Django: 3.2, 4.1, 4.2, 5.0, 5.1
 - You can view the [Python-Django support matrix
   here](https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django)
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{38,39,310,311}-django4.1,
     py{38,39,310,311,312}-django4.2,
     py{310,311,312}-django50,
+    py{310,311,312}-django51,
 
 [testenv]
 deps =
@@ -11,6 +12,7 @@ deps =
     django4.1: Django~=4.1.0
     django4.2: Django~=4.2.0
     django5.0: Django~=5.0.0
+    django5.1: Django~=5.1.0
     djangomain: https://github.com/django/django/archive/main.tar.gz
     coverage
 commands =


### PR DESCRIPTION
Was [released several months ago.](https://docs.djangoproject.com/en/5.1/releases/5.1/)