### PR TITLE
Add and improve key checks related to issues 160 and 381.

### DIFF
--- a/django_recaptcha/checks.py
+++ b/django_recaptcha/checks.py
@@ -10,24 +10,30 @@ def recaptcha_key_check(app_configs, **kwargs):
     public_key = getattr(settings, "RECAPTCHA_PUBLIC_KEY", TEST_PUBLIC_KEY)
 
     if private_key == "":
-        errors.extend([
-            checks.Error(
-                "RECAPTCHA_PRIVATE_KEY is an empty string.",
-                hint="Remove RECAPTCHA_PRIVATE_KEY from your settings file, or provide a proper key.",
-                id="django_recaptcha.private_key_is_empty_string",
-            )
-        ])
+        errors.extend(
+            [
+                checks.Error(
+                    "RECAPTCHA_PRIVATE_KEY is an empty string.",
+                    hint="Remove RECAPTCHA_PRIVATE_KEY from your settings file, or provide a proper key.",
+                    id="django_recaptcha.private_key_is_empty_string",
+                )
+            ]
+        )
 
     if public_key == "":
-        errors.extend([
-            checks.Error(
-                "RECAPTCHA_PUBLIC_KEY is an empty string.",
-                hint="Remove RECAPTCHA_PUBLIC_KEY from your settings file, or provide a proper key.",
-                id="django_recaptcha.public_key_is_empty_string",
-            )
-        ])
+        errors.extend(
+            [
+                checks.Error(
+                    "RECAPTCHA_PUBLIC_KEY is an empty string.",
+                    hint="Remove RECAPTCHA_PUBLIC_KEY from your settings file, or provide a proper key.",
+                    id="django_recaptcha.public_key_is_empty_string",
+                )
+            ]
+        )
 
-    if not settings.DEBUG and (private_key == TEST_PRIVATE_KEY or public_key == TEST_PUBLIC_KEY):
+    if not settings.DEBUG and (
+        private_key == TEST_PRIVATE_KEY or public_key == TEST_PUBLIC_KEY
+    ):
         errors.extend(
             [
                 checks.Error(

--- a/django_recaptcha/checks.py
+++ b/django_recaptcha/checks.py
@@ -9,6 +9,24 @@ def recaptcha_key_check(app_configs, **kwargs):
     private_key = getattr(settings, "RECAPTCHA_PRIVATE_KEY", TEST_PRIVATE_KEY)
     public_key = getattr(settings, "RECAPTCHA_PUBLIC_KEY", TEST_PUBLIC_KEY)
 
+    if private_key == "":
+        errors.extend([
+            checks.Error(
+                "RECAPTCHA_PRIVATE_KEY is an empty string.",
+                hint="Remove RECAPTCHA_PRIVATE_KEY from your settings file, or provide a proper key.",
+                id="django_recaptcha.private_key_is_empty_string",
+            )
+        ])
+
+    if public_key == "":
+        errors.extend([
+            checks.Error(
+                "RECAPTCHA_PUBLIC_KEY is an empty string.",
+                hint="Remove RECAPTCHA_PUBLIC_KEY from your settings file, or provide a proper key.",
+                id="django_recaptcha.public_key_is_empty_string",
+            )
+        ])
+
     if not settings.DEBUG and (private_key == TEST_PRIVATE_KEY or public_key == TEST_PUBLIC_KEY):
         errors.extend(
             [

--- a/django_recaptcha/checks.py
+++ b/django_recaptcha/checks.py
@@ -9,7 +9,7 @@ def recaptcha_key_check(app_configs, **kwargs):
     private_key = getattr(settings, "RECAPTCHA_PRIVATE_KEY", TEST_PRIVATE_KEY)
     public_key = getattr(settings, "RECAPTCHA_PUBLIC_KEY", TEST_PUBLIC_KEY)
 
-    if private_key == TEST_PRIVATE_KEY or public_key == TEST_PUBLIC_KEY:
+    if not settings.DEBUG and (private_key == TEST_PRIVATE_KEY or public_key == TEST_PUBLIC_KEY):
         errors.extend(
             [
                 checks.Error(

--- a/django_recaptcha/tests/test_checks.py
+++ b/django_recaptcha/tests/test_checks.py
@@ -2,6 +2,7 @@ from django.test import TestCase, override_settings
 
 from django.core.checks import Error
 import django_recaptcha
+from django_recaptcha.constants import TEST_PRIVATE_KEY
 
 
 class TestChecks(TestCase):
@@ -35,22 +36,11 @@ class TestChecks(TestCase):
         self.assertEqual(1, len(relevant_errs))
 
     @override_settings(
-        RECAPTCHA_PRIVATE_KEY=django_recaptcha.constants.TEST_PRIVATE_KEY
+        DEBUG=False,
+        RECAPTCHA_PRIVATE_KEY=TEST_PRIVATE_KEY,
     )
-    def test_test_key_check(self):
-        check_errors = django_recaptcha.checks.recaptcha_key_check("someconf")
-        expected_errors = [
-            Error(
-                "RECAPTCHA_PRIVATE_KEY or RECAPTCHA_PUBLIC_KEY is making use"
-                " of the Google test keys and will not behave as expected in a"
-                " production environment",
-                hint="Update settings.RECAPTCHA_PRIVATE_KEY"
-                " and/or settings.RECAPTCHA_PUBLIC_KEY. Alternatively this"
-                " check can be ignored by adding"
-                " `SILENCED_SYSTEM_CHECKS ="
-                " ['django_recaptcha.recaptcha_test_key_error']`"
-                " to your settings file.",
-                id="django_recaptcha.recaptcha_test_key_error",
-            )
-        ]
-        self.assertEqual(check_errors, expected_errors)
+    def test_check_test_key_usage_fails(self):
+        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
+        relevant_errs = [e for e in errs if e.id == "django_recaptcha.recaptcha_test_key_error"]
+
+        self.assertEqual(1, len(relevant_errs))

--- a/django_recaptcha/tests/test_checks.py
+++ b/django_recaptcha/tests/test_checks.py
@@ -1,58 +1,61 @@
 from django.test import TestCase, override_settings
 
-import django_recaptcha
 from django_recaptcha.checks import recaptcha_key_check
 from django_recaptcha.constants import TEST_PRIVATE_KEY
-from django_recaptcha.tests.settings.coveralls_settings import RECAPTCHA_PUBLIC_KEY
+
+
+def _filter_errs(errs, err_id):
+    """Returns filtered list with relevant error."""
+    return [e for e in errs if e.id == err_id]
 
 
 class TestChecks(TestCase):
 
     @override_settings(RECAPTCHA_PRIVATE_KEY="notempty")
     def test_check_private_key_is_empty_passes(self):
-        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
-        relevant_errs = [e for e in errs if e.id == "django_recaptcha.private_key_is_empty_string"]
+        errs = recaptcha_key_check("someconf")
+        errs = _filter_errs(errs, "django_recaptcha.private_key_is_empty_string")
 
-        self.assertEqual(0, len(relevant_errs))
+        self.assertEqual(0, len(errs))
 
     @override_settings(RECAPTCHA_PRIVATE_KEY="")
     def test_check_private_key_is_empty_fails(self):
-        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
-        relevant_errs = [e for e in errs if e.id == "django_recaptcha.private_key_is_empty_string"]
+        errs = recaptcha_key_check("someconf")
+        errs = _filter_errs(errs, "django_recaptcha.private_key_is_empty_string")
 
-        self.assertEqual(1, len(relevant_errs))
+        self.assertEqual(1, len(errs))
 
     @override_settings(RECAPTCHA_PUBLIC_KEY="notempty")
     def test_check_public_key_is_empty_passes(self):
-        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
-        relevant_errs = [e for e in errs if e.id == "django_recaptcha.public_key_is_empty_string"]
+        errs = recaptcha_key_check("someconf")
+        errs = _filter_errs(errs, "django_recaptcha.public_key_is_empty_string")
 
-        self.assertEqual(0, len(relevant_errs))
+        self.assertEqual(0, len(errs))
 
     @override_settings(RECAPTCHA_PUBLIC_KEY="")
     def test_check_public_key_is_empty_fails(self):
-        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
-        relevant_errs = [e for e in errs if e.id == "django_recaptcha.public_key_is_empty_string"]
+        errs = recaptcha_key_check("someconf")
+        errs = _filter_errs(errs, "django_recaptcha.public_key_is_empty_string")
 
-        self.assertEqual(1, len(relevant_errs))
+        self.assertEqual(1, len(errs))
 
     @override_settings(DEBUG=True, RECAPTCHA_PRIVATE_KEY=TEST_PRIVATE_KEY)
     def test_check_test_key_usage_skipped(self):
-        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
-        relevant_errs = [e for e in errs if e.id == "django_recaptcha.recaptcha_test_key_error"]
+        errs = recaptcha_key_check("someconf")
+        errs = _filter_errs(errs, "django_recaptcha.recaptcha_test_key_error")
 
-        self.assertEqual(0, len(relevant_errs))
+        self.assertEqual(0, len(errs))
 
     @override_settings(DEBUG=False, RECAPTCHA_PRIVATE_KEY="privatekey", RECAPTCHA_PUBLIC_KEY="publickey")
     def test_check_test_key_usage_passes(self):
-        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
-        relevant_errs = [e for e in errs if e.id == "django_recaptcha.recaptcha_test_key_error"]
+        errs = recaptcha_key_check("someconf")
+        errs = _filter_errs(errs, "django_recaptcha.recaptcha_test_key_error")
 
-        self.assertEqual(0, len(relevant_errs))
+        self.assertEqual(0, len(errs))
 
     @override_settings(DEBUG=False, RECAPTCHA_PRIVATE_KEY=TEST_PRIVATE_KEY)
     def test_check_test_key_usage_fails(self):
-        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
-        relevant_errs = [e for e in errs if e.id == "django_recaptcha.recaptcha_test_key_error"]
+        errs = recaptcha_key_check("someconf")
+        errs = _filter_errs(errs, "django_recaptcha.recaptcha_test_key_error")
 
-        self.assertEqual(1, len(relevant_errs))
+        self.assertEqual(1, len(errs))

--- a/django_recaptcha/tests/test_checks.py
+++ b/django_recaptcha/tests/test_checks.py
@@ -46,7 +46,11 @@ class TestChecks(TestCase):
 
         self.assertEqual(0, len(errs))
 
-    @override_settings(DEBUG=False, RECAPTCHA_PRIVATE_KEY="privatekey", RECAPTCHA_PUBLIC_KEY="publickey")
+    @override_settings(
+        DEBUG=False,
+        RECAPTCHA_PRIVATE_KEY="privatekey",
+        RECAPTCHA_PUBLIC_KEY="publickey",
+    )
     def test_check_test_key_usage_passes(self):
         errs = recaptcha_key_check("someconf")
         errs = _filter_errs(errs, "django_recaptcha.recaptcha_test_key_error")

--- a/django_recaptcha/tests/test_checks.py
+++ b/django_recaptcha/tests/test_checks.py
@@ -1,8 +1,9 @@
 from django.test import TestCase, override_settings
 
-from django.core.checks import Error
 import django_recaptcha
+from django_recaptcha.checks import recaptcha_key_check
 from django_recaptcha.constants import TEST_PRIVATE_KEY
+from django_recaptcha.tests.settings.coveralls_settings import RECAPTCHA_PUBLIC_KEY
 
 
 class TestChecks(TestCase):
@@ -35,10 +36,21 @@ class TestChecks(TestCase):
 
         self.assertEqual(1, len(relevant_errs))
 
-    @override_settings(
-        DEBUG=False,
-        RECAPTCHA_PRIVATE_KEY=TEST_PRIVATE_KEY,
-    )
+    @override_settings(DEBUG=True, RECAPTCHA_PRIVATE_KEY=TEST_PRIVATE_KEY)
+    def test_check_test_key_usage_skipped(self):
+        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
+        relevant_errs = [e for e in errs if e.id == "django_recaptcha.recaptcha_test_key_error"]
+
+        self.assertEqual(0, len(relevant_errs))
+
+    @override_settings(DEBUG=False, RECAPTCHA_PRIVATE_KEY="privatekey", RECAPTCHA_PUBLIC_KEY="publickey")
+    def test_check_test_key_usage_passes(self):
+        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
+        relevant_errs = [e for e in errs if e.id == "django_recaptcha.recaptcha_test_key_error"]
+
+        self.assertEqual(0, len(relevant_errs))
+
+    @override_settings(DEBUG=False, RECAPTCHA_PRIVATE_KEY=TEST_PRIVATE_KEY)
     def test_check_test_key_usage_fails(self):
         errs = django_recaptcha.checks.recaptcha_key_check("someconf")
         relevant_errs = [e for e in errs if e.id == "django_recaptcha.recaptcha_test_key_error"]

--- a/django_recaptcha/tests/test_checks.py
+++ b/django_recaptcha/tests/test_checks.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, override_settings
 
+from django.core.checks import Error
 import django_recaptcha
 
 
@@ -32,3 +33,24 @@ class TestChecks(TestCase):
         relevant_errs = [e for e in errs if e.id == "django_recaptcha.public_key_is_empty_string"]
 
         self.assertEqual(1, len(relevant_errs))
+
+    @override_settings(
+        RECAPTCHA_PRIVATE_KEY=django_recaptcha.constants.TEST_PRIVATE_KEY
+    )
+    def test_test_key_check(self):
+        check_errors = django_recaptcha.checks.recaptcha_key_check("someconf")
+        expected_errors = [
+            Error(
+                "RECAPTCHA_PRIVATE_KEY or RECAPTCHA_PUBLIC_KEY is making use"
+                " of the Google test keys and will not behave as expected in a"
+                " production environment",
+                hint="Update settings.RECAPTCHA_PRIVATE_KEY"
+                " and/or settings.RECAPTCHA_PUBLIC_KEY. Alternatively this"
+                " check can be ignored by adding"
+                " `SILENCED_SYSTEM_CHECKS ="
+                " ['django_recaptcha.recaptcha_test_key_error']`"
+                " to your settings file.",
+                id="django_recaptcha.recaptcha_test_key_error",
+            )
+        ]
+        self.assertEqual(check_errors, expected_errors)

--- a/django_recaptcha/tests/test_checks.py
+++ b/django_recaptcha/tests/test_checks.py
@@ -1,0 +1,34 @@
+from django.test import TestCase, override_settings
+
+import django_recaptcha
+
+
+class TestChecks(TestCase):
+
+    @override_settings(RECAPTCHA_PRIVATE_KEY="notempty")
+    def test_check_private_key_is_empty_passes(self):
+        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
+        relevant_errs = [e for e in errs if e.id == "django_recaptcha.private_key_is_empty_string"]
+
+        self.assertEqual(0, len(relevant_errs))
+
+    @override_settings(RECAPTCHA_PRIVATE_KEY="")
+    def test_check_private_key_is_empty_fails(self):
+        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
+        relevant_errs = [e for e in errs if e.id == "django_recaptcha.private_key_is_empty_string"]
+
+        self.assertEqual(1, len(relevant_errs))
+
+    @override_settings(RECAPTCHA_PUBLIC_KEY="notempty")
+    def test_check_public_key_is_empty_passes(self):
+        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
+        relevant_errs = [e for e in errs if e.id == "django_recaptcha.public_key_is_empty_string"]
+
+        self.assertEqual(0, len(relevant_errs))
+
+    @override_settings(RECAPTCHA_PUBLIC_KEY="")
+    def test_check_public_key_is_empty_fails(self):
+        errs = django_recaptcha.checks.recaptcha_key_check("someconf")
+        relevant_errs = [e for e in errs if e.id == "django_recaptcha.public_key_is_empty_string"]
+
+        self.assertEqual(1, len(relevant_errs))

--- a/django_recaptcha/tests/tests.py
+++ b/django_recaptcha/tests/tests.py
@@ -1,6 +1,5 @@
 from importlib import reload
 
-from django.core.checks import Error
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 
@@ -42,24 +41,3 @@ class TestInit(TestCase):
                 error.exception.args,
                 ("Setting RECAPTCHA_PRIVATE_KEY is not of type", str),
             )
-
-    @override_settings(
-        RECAPTCHA_PRIVATE_KEY=django_recaptcha.constants.TEST_PRIVATE_KEY
-    )
-    def test_test_key_check(self):
-        check_errors = django_recaptcha.checks.recaptcha_key_check("someconf")
-        expected_errors = [
-            Error(
-                "RECAPTCHA_PRIVATE_KEY or RECAPTCHA_PUBLIC_KEY is making use"
-                " of the Google test keys and will not behave as expected in a"
-                " production environment",
-                hint="Update settings.RECAPTCHA_PRIVATE_KEY"
-                " and/or settings.RECAPTCHA_PUBLIC_KEY. Alternatively this"
-                " check can be ignored by adding"
-                " `SILENCED_SYSTEM_CHECKS ="
-                " ['django_recaptcha.recaptcha_test_key_error']`"
-                " to your settings file.",
-                id="django_recaptcha.recaptcha_test_key_error",
-            )
-        ]
-        self.assertEqual(check_errors, expected_errors)


### PR DESCRIPTION
These changes should resolve #160 and resolve #381.

Although I proposed not to introduce any breaking changes for the 4.2 release in #383, the extra checks for empty string keys can technically break existing deployments. It's most likely that, when this is the case, the deployment is already bricked in the first place. However, there's still the possibility that someone has misconfigured their settings, but provides proper keys to their `ReCaptchaField`s directly, so that the misconfiguration is masked without any issues. Should we replace these errors with warnings?