### PR TITLE
Add documentation for `recaptcha_response` property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,33 @@ captcha = fields.ReCaptchaField(
 
 Setting an action is entirely optional. If you don't specify an action, no action will be passed to the reCAPTCHA V3 API.
 
+
+### Accessing reCAPTCHA response data
+
+As of version 4.2 of django-recaptcha, you can access the data of the response returned by the reCAPTCHA API after validation through a field's `recaptcha_response` property.
+It's an instance of `RecaptchaResponse`, which has four members:
+
+- `is_valid`
+  - corresponds to response object's `"success"` field
+  - was token valid? (`True` or `False`)
+- `error_codes`
+  - corresponds to response object's `"error-codes"` field
+  - a list of error codes (e.g. `["missing-input-secret"]`)
+- `action`
+  - corresponds to response object's `"action"` field
+  - `str` or `None`
+- `extra_data`
+  - a `dict` instance with the response object's other fields
+
+For example, if you're using reCAPTCHA v3 and want to access the score AFTER validation,
+you can attempt to access the score as demonstrated:
+
+```python
+score = captcha.recaptcha_response.extra_data.get("score")
+```
+
+It's value is `None` before validation.
+
 ### Local Development and Functional Testing
 
 If `RECAPTCHA_PUBLIC_KEY` and `RECAPTCHA_PRIVATE_KEY` are not set,

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [Widgets](#widgets)
   - [reCAPTCHA V3 Score](#recaptcha-v3-score)
   - [reCAPTCHA V3 Action](#recaptcha-v3-action)
+  - [Accessing reCAPTCHA response data](#accessing-recaptcha-response-data)
   - [Local Development and Functional Testing](#local-development-and-functional-testing)
 - [Credits](#credits)
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ It's an instance of `RecaptchaResponse`, which has four members:
   - a list of error codes (e.g. `["missing-input-secret"]`)
 - `action`
   - corresponds to response object's `"action"` field
-  - `str` or `None`
+  - `str` or `None` (e.g. `"login"`)
 - `extra_data`
   - a `dict` instance with the response object's other fields
 
@@ -274,7 +274,7 @@ you can attempt to access the score as demonstrated:
 score = captcha.recaptcha_response.extra_data.get("score")
 ```
 
-It's value is `None` before validation.
+Its value is `None` before validation.
 
 ### Local Development and Functional Testing
 


### PR DESCRIPTION
This PR adds documentation for the `recaptcha_response` property, as discussed in #382.
